### PR TITLE
Adjust USI patch

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
@@ -337,7 +337,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.85
+			Ratio = 0.55
 		}
 	}
 
@@ -368,7 +368,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.85
+			Ratio = 0.55
 		}
 	}
 
@@ -390,7 +390,7 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 118
+		BaseKerbalMonths = 209
 		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
 		BaseHabMultiplier = 2
 		ConverterName = Habitat
@@ -399,7 +399,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 7.9
+			Ratio = 12.45
 		}
 	}
 
@@ -421,7 +421,7 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 70
+		BaseKerbalMonths = 93
 		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
 		BaseHabMultiplier = 1
 		ConverterName = Habitat
@@ -430,7 +430,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 4.5
+			Ratio = 5.65
 		}
 	}
 
@@ -483,7 +483,7 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 20
+		BaseKerbalMonths = 10
 		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
 		BaseHabMultiplier = 0.6
 		ConverterName = Habitat
@@ -492,7 +492,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 2.9
+			Ratio = 2.65
 		}
 	}
 }


### PR DESCRIPTION
- Adjust the habitation extra time and EC usage.
- 2.5m Expandable Hab is buffed to reflect more beds in the modules. 8 beds per 9 crew for smaller one. 16 beds per 18 crew for the larger one.
-The 1.25m compact centrifuge is nerfed due to its low amount of bed. (2 beds for 4 crew)
-Fix incorrect EC rate for both Winston habs.