### PR TITLE
Adjust stats on many parts.

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
@@ -297,7 +297,7 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 14
+		BaseKerbalMonths = 19
 		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
 		BaseHabMultiplier = 0.6
 		ConverterName = Habitat
@@ -306,7 +306,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 1.3
+			Ratio = 1.55
 		}
 	}
 
@@ -328,16 +328,16 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 11
+		BaseKerbalMonths = 7
 		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 0
+		BaseHabMultiplier = 0.3
 		ConverterName = Habitat
 		StartActionName = Start Habitat
 		StopActionName = Stop Habitat
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.55
+			Ratio = 0.65
 		}
 	}
 
@@ -359,16 +359,16 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 11
+		BaseKerbalMonths = 7
 		CrewCapacity = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
-		BaseHabMultiplier = 0
+		BaseHabMultiplier = 0.3
 		ConverterName = Habitat
 		StartActionName = Start Habitat
 		StopActionName = Stop Habitat
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 0.55
+			Ratio = 0.65
 		}
 	}
 
@@ -543,7 +543,7 @@
 	MODULE
 	{
 		name = ModuleHabitation
-		BaseKerbalMonths = 360
+		BaseKerbalMonths = 288
 		CrewCapacity = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
 		BaseHabMultiplier = 3.9
 		ConverterName = Habitat
@@ -552,7 +552,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 50.325
+			Ratio = 48.525
 		}
 	}
 }


### PR DESCRIPTION
- Buffing up large 1.25m inflatable hab, It got a bit more bed now. Increase extra time. (4 beds instead of 3)
- Adjust 1.25 m small inflatable hab according to new IVA (Now 2 hammocks instead of 3), a slight reduction in extramonth but increase in multiplier a little bit due to extra space.
- Decrease extramonth in the large 3.75m centrifuge to follow up the new IVA with a slightly lesser bed. (8 instead of 10)