### PR TITLE
New tags, KeepFit patch, fix CLS patch

### DIFF
--- a/GameData/StationPartsExpansionRedux/Localization/en-us.cfg
+++ b/GameData/StationPartsExpansionRedux/Localization/en-us.cfg
@@ -11,43 +11,43 @@ Localization
     // 5m rigid parts
     #LOC_SSPX_sspx-habitation-5-1_title = SDV-2 'Atlas' Deep Space Habitation Module
     #LOC_SSPX_sspx-habitation-5-1_description = Future part
-    #LOC_SSPX_sspx-habitation-5-1_tags = base cabin outpost passenger statio tour (hab sspx
+    #LOC_SSPX_sspx-habitation-5-1_tags = base cabin outpost passenger statio tour (hab sspx atlas
 
     #LOC_SSPX_sspx-core-5-1_title = SDV-3 'Minerva' Deep Space Control Module
     #LOC_SSPX_sspx-core-5-1_description = Future part
-    #LOC_SSPX_sspx-core-5-1_tags = base cabin outpost passenger statio tour (hab sspx center central connect construct (core hub nexus outpost statio reaction rotate wheel
+    #LOC_SSPX_sspx-core-5-1_tags = base cabin outpost passenger statio tour (hab sspx center central connect construct (core hub nexus outpost statio reaction rotate wheel minerva
 
     #LOC_SSPX_sspx-logistics-5-1_title = SDV-1 'Leto' Deep Space Logistics Module
     #LOC_SSPX_sspx-logistics-5-1_description = Future part
-    #LOC_SSPX_sspx-logistics-5-1_tags = base cabin outpost passenger statio tour (hab sspx cargo contain commodity transport stor logist
+    #LOC_SSPX_sspx-logistics-5-1_tags = base cabin outpost passenger statio tour (hab sspx cargo contain commodity transport stor logist leto
 
     // 5m expandable parts
     #LOC_SSPX_sspx-extensible-centrifuge-5-1_title = SDV-X 'Cronus' Extensible Centrifuge
     #LOC_SSPX_sspx-extensible-centrifuge-5-1_description = Future part
-    #LOC_SSPX_sspx-extensible-centrifuge-5-1_tags = sspx base contain outpost statio (stor tube inflat expand donut spin centrifuge wheel gravity
+    #LOC_SSPX_sspx-extensible-centrifuge-5-1_tags = sspx base contain outpost statio (stor tube inflat expand donut spin centrifuge wheel gravity cronus
 
     // 3.75m rigid parts
     #LOC_SSPX_sspx-cupola-375-1_title = PXL-9 'Vista' Astrogation Module
     #LOC_SSPX_sspx-cupola-375-1_description = Useful for observing planets, spotting stars and just overall increasing your ship's total window count. Functions as both an observation center and a basic control room. Has integrated EVA rails.
-    #LOC_SSPX_sspx-cupola-375-1_tags = base capsule cmg command control ?eva fly gyro ?iva moment outpost pilot pod react rocket space stab statio steer torque view sspx
+    #LOC_SSPX_sspx-cupola-375-1_tags = base capsule cmg command control cupola ?eva fly gyro ?iva moment obs outpost pilot pod react rocket space stab statio steer torque view sspx vista
 
     #LOC_SSPX_sspx-habitation-375-1_title = PXL-1 'Hostel' Deep-Space Habitation Module
     #LOC_SSPX_sspx-habitation-375-1_description = The largest rigid-hulled habitat, the Hostel has space for up to twelve Kerbals with individual cabins. Designed for deep space, it has adequate radiation protection and contains a full suite of hygiene and exercise equipment. Has integrated EVA rails.
-    #LOC_SSPX_sspx-habitation-375-1_tags = base cabin outpost passenger statio tour (hab sspx hermes martian
+    #LOC_SSPX_sspx-habitation-375-1_tags = base cabin outpost passenger statio tour (hab sspx hermes martian hostel
     #LOC_SSPX_sspx-habitation-375-2_title = PXL-2 'Shelter' Deep-Space Habitation Module
     #LOC_SSPX_sspx-habitation-375-2_description = A six-Kerbal module, the rigid-shelled Shelter has space for six Kerbals who can sleep in nicely furnished if somewhat cramped sleeping cells. Tough outer walls give radiation protection and peace of mind. Has integrated EVA rails.
-    #LOC_SSPX_sspx-habitation-375-2_tags = base cabin outpost passenger statio tour (hab sspx hermes martian
+    #LOC_SSPX_sspx-habitation-375-2_tags = base cabin outpost passenger statio tour (hab sspx hermes martian shelter
     #LOC_SSPX_sspx-habitation-375-3_title = PXL-3 'Asylum' Storm Cellar Module
     #LOC_SSPX_sspx-habitation-375-3_description = In case of a solar flare, it could be useful to provide a module with extra shielding, in which the crew can hunker down. The main shielding is provided by radial fuel tanks between the hull and the shelter. Six Kerbals can hide here in cramped conditions, with three bunks for long waits. Has integrated EVA rails.
-    #LOC_SSPX_sspx-habitation-375-3_tags = base cabin outpost passenger statio tour (hab sspx hermes martian
+    #LOC_SSPX_sspx-habitation-375-3_tags = base cabin outpost passenger statio tour (hab sspx hermes martian asylum
 
     #LOC_SSPX_sspx-lab-375-1_title = PXL-2 'Fate' Deep-Space Laboratory Module
     #LOC_SSPX_sspx-lab-375-1_description = Doing science in deep space is pretty much the same as doing science in regular space. This well-appointed lab was recently renovated with a full remodel - the owner has added an experiment airlock to complement the modern facilities. Has integrated EVA rails.
-    #LOC_SSPX_sspx-lab-375-1_tags = sspx experiment laboratory research science hermes martian cck-lifesupport
+    #LOC_SSPX_sspx-lab-375-1_tags = sspx experiment laboratory research science hermes martian cck-lifesupport fate
 
     #LOC_SSPX_sspx-greenhouse-375-1_title = PXL-R4NCH-3R Hydroponics Module
     #LOC_SSPX_sspx-greenhouse-375-1_description = This wide greenhouse module can supply several Kerbals with a sufficient supply of kale to make them wish they didn't have a supply of kale. Has integrated EVA rails.
-    #LOC_SSPX_sspx-greenhouse-375-1_tags = sspx base outpost grow farm hydro plant greenhouse kale cck-lifesupport
+    #LOC_SSPX_sspx-greenhouse-375-1_tags = sspx base outpost grow farm hydro plant greenhouse kale cck-lifesupport ranch
 
     #LOC_SSPX_sspx-aquaculture-375-1_title = PXL-F15H Aquaculture Module
     #LOC_SSPX_sspx-aquaculture-375-1_description = For additional variety in food production and radiation protection, Kerbalmax has designed the weighty acquculture module. Various tanks hold delicious morsels ranging from smelt, through blowfish, to shramp. Hopefully using radiation shielding as a growing medium won't have any side effects. Has integrated EVA rails.
@@ -59,7 +59,7 @@ Localization
 
     #LOC_SSPX_sspx-core-375-1_title = PXL-10 'Harbour' Station Control Centre
     #LOC_SSPX_sspx-core-375-1_description = An extra-large control centre for large structures or spacecraft. Houses up to five Kerbals and functions as a fully-equipped probe control centre. Well shielded for deep-space operations - just don't bring the fleet out of hyperspace too close to the planet.
-    #LOC_SSPX_sspx-core-375-1_tags = sspx base build center central connect construct (core hub nexus outpost statio reaction rotate wheel
+    #LOC_SSPX_sspx-core-375-1_tags = sspx base build center central connect construct (core hub nexus outpost statio reaction rotate wheel harbor harbour
 
     #LOC_SSPX_sspx-cargo-container-375-1_title = PXL-CRG-1 Logistics Module
     #LOC_SSPX_sspx-cargo-container-375-1_description =  A long 3.75m logistics module, storing a wide variety of possible commodities.
@@ -86,11 +86,11 @@ Localization
     // 3.75m expandable parts
     #LOC_SSPX_sspx-extensible-centrifuge-375-1_title = PXL-E 'Mercury' Extensible Centrifuge
     #LOC_SSPX_sspx-extensible-centrifuge-375-1_description = A truly enormous centrifuge of 25m diameter when fully deployed. Allows a spin gravity of up to 0.6g at a comfortably slow rotation rate and space for up to 14 brave Kerbals. A fully integrated living solution, the Mercury has a well-appointed kitchen, exercise equipment and a medical facility. With ten individual cabins, crew rotations are less arduous.
-    #LOC_SSPX_sspx-extensible-centrifuge-375-1_tags = sspx base contain outpost statio (stor tube inflat expand spin centrifuge wheel gravity hermes martian
+    #LOC_SSPX_sspx-extensible-centrifuge-375-1_tags = sspx base contain outpost statio (stor tube inflat expand spin centrifuge wheel gravity hermes martian mercury
 
     #LOC_SSPX_sspx-extensible-centrifuge-375-2_title = PXL-F 'Pilgrim' Extensible Centrifuge
     #LOC_SSPX_sspx-extensible-centrifuge-375-2_description = A somewhat compact centrifuge with an innovative "multi-gravity" design. Each of the decks has a different spin gravity, increasing the challenge level for crew! Every arm has a similar configuration, with exercise areas, kitchen facility and sleeping zones. Holds up to 10 Kerbals.
-    #LOC_SSPX_sspx-extensible-centrifuge-375-2_tags = sspx base contain outpost statio (stor tube inflat expand spin centrifuge wheel gravity
+    #LOC_SSPX_sspx-extensible-centrifuge-375-2_tags = sspx base contain outpost statio (stor tube inflat expand spin centrifuge wheel gravity pilgrim
 
     // 2.5m rigid parts
     #LOC_SSPX_sspx-tube-25-1_title = PPD-A1 Pressurized Crew Tube
@@ -113,7 +113,7 @@ Localization
 
     #LOC_SSPX_sspx-core-25-1_title = PPD-8 'Wharf' Station Core
     #LOC_SSPX_sspx-core-25-1_description = The Wharf serves a singular purpose: allowing Kerbals to control their station. Well insulated and spaciously equipped, up to four Kerbals can work here with a full probe control facility and minor creature comforts.
-    #LOC_SSPX_sspx-core-25-1_tags = sspx base build center central connect construct (core hub nexus outpost statio reaction rotate wheel
+    #LOC_SSPX_sspx-core-25-1_tags = sspx base build center central connect construct (core hub nexus outpost statio reaction rotate wheel wharf
 
     #LOC_SSPX_sspx-hub-25-1_title = PPD-MULT Multi-Point Station Connector
     #LOC_SSPX_sspx-hub-25-1_description = Sometimes, you just need a little more hub. This hub provides, in spades! Any connection is possible, from class 6-way to angled 45 and 30 degree mounts. Order today!
@@ -121,11 +121,11 @@ Localization
 
     #LOC_SSPX_sspx-observation-25-1_title = PPD-24 'Panorama' Observation Module
     #LOC_SSPX_sspx-observation-25-1_description = The PPD-24 is a great addition to any surface or orbital base, and allows for both high visibility and heat loss for the four Kerbals inside. This second-generation model adds surface decoration and reduces the number of airlocks to one.
-    #LOC_SSPX_sspx-observation-25-1_tags = base cmg ?eva fly gyro ?iva moment outpost react space stab statio view sspx
+    #LOC_SSPX_sspx-observation-25-1_tags = base cmg cupola ?eva fly gyro ?iva moment obs outpost react space stab statio view sspx panorama
 
     #LOC_SSPX_sspx-habitation-25-1_title = PPD-20 'Shanty' Habitation Module
     #LOC_SSPX_sspx-habitation-25-1_description = Though the venerable Hitchhiker gives us a place to easily store Kerbals on-orbit, a larger module can store them for even longer. The Shanty comes equipped with all you need for operating a six-Kerbal space slum - more chairs than beds and even backup supplies of monopropellant and electric charge.
-    #LOC_SSPX_sspx-habitation-25-1_tags = base cabin outpost passenger statio tour (hab sspx fuel e/c ec battery can hab liv sleep
+    #LOC_SSPX_sspx-habitation-25-1_tags = base cabin outpost passenger statio tour (hab sspx fuel e/c ec battery can hab liv sleep shanty
 
     #LOC_SSPX_sspx-greenhouse-25-1_title = PPD-F412M Hydroponics Module
     #LOC_SSPX_sspx-greenhouse-25-1_description = Long expeditions might supplement their life support supplies with orbitally-grown produce. After extensive experiments, it was found that the best, most compact, most nutritious plant that could be grown was of course Kale. Unfortunately for the Kerbalnauts, the vegetable's taste was found to be sub-par.
@@ -136,7 +136,7 @@ Localization
     #LOC_SSPX_sspx-cargo-25-1_tags = sspx cargo stor outpost statio store
     #LOC_SSPX_sspx-cargo-25-2_title = PPD-TRUSS-S Storage Module
     #LOC_SSPX_sspx-cargo-25-2_description = The larger PPD-series storage modules can contain a lot of utility parts and stow many things on orbit. This model is shorter and has two less doors.
-    #LOC_SSPX_sspx-cargo-25-2_tags = sspx cargo  stor outpost statio store
+    #LOC_SSPX_sspx-cargo-25-2_tags = sspx cargo  stor outpost statio store truss
 
     #LOC_SSPX_sspx-cargo-container-25-1_title = PPD-CRG-1 Logistics Module
     #LOC_SSPX_sspx-cargo-container-25-1_description =  A long 2.5m logistics module, storing a wide variety of possible commodities.
@@ -153,14 +153,14 @@ Localization
     // 2.5m inflatable parts
     #LOC_SSPX_sspx-inflatable-hab-25-1_title =  PFD-A 'Dirigible' Inflatable Habitation Module
     #LOC_SSPX_sspx-inflatable-hab-25-1_description = The single largest inflatable habitat on the market. Holds many Kerbals (eighteen!) in some comfort. Limited sleeping space means that only nine Kerbals have beds at once - however the others can relax in common areas, take a shower, congregate in a wardroom or take turns at the exercise equipment.
-    #LOC_SSPX_sspx-inflatable-hab-25-1_tags = sspx base contain outpost statio (stor tube (hab liv inflat expand
+    #LOC_SSPX_sspx-inflatable-hab-25-1_tags = sspx base contain outpost statio (stor tube (hab liv inflat expand blimp dirigible
     #LOC_SSPX_sspx-inflatable-hab-25-2_title = PFD-B 'Blimp' Inflatable Habitation Module
     #LOC_SSPX_sspx-inflatable-hab-25-2_description = A smaller  but large inflatable habitat. Still, nine Kerbals is a pretty nice amount for its low footprint when compressed. Six beds are available with lots of room to move around. In addition, full shower and toilet facilities are available.
-    #LOC_SSPX_sspx-inflatable-hab-25-2_tags = sspx base contain outpost statio (stor tube (hab liv inflat expand
+    #LOC_SSPX_sspx-inflatable-hab-25-2_tags = sspx base contain outpost statio (stor tube (hab liv inflat expand blimp dirigible
 
     #LOC_SSPX_sspx-inflatable-centrifuge-25-1_title = PFD-C 'Coriolis' Inflatable Centrifuge Module
     #LOC_SSPX_sspx-inflatable-centrifuge-25-1_description = The largest available inflatable centrifuge provides living area for eight Kerbals in great comfort. Expanded to its diameter of 15m and spinning, it provides a solid 0.5g of gravity, helping with all sorts of health issues. Contains some exercise equipment, a wardroom, common areas - the works!
-    #LOC_SSPX_sspx-inflatable-centrifuge-25-1_tags = sspx base contain outpost statio (stor tube inflat expand donut spin centrifuge wheel gravity (hab liv
+    #LOC_SSPX_sspx-inflatable-centrifuge-25-1_tags = sspx base contain outpost statio (stor tube inflat expand donut spin centrifuge wheel gravity (hab liv coriolis
 
     // Adapters
     #LOC_SSPX_sspx-adapter-375-5-1_title = SDV-4 Adapter
@@ -201,13 +201,13 @@ Localization
 
     #LOC_SSPX_sspx-core-125-1_title = PTD-8R 'Pier' Station Core
     #LOC_SSPX_sspx-core-125-1_description = The low tech Pier provides a place for running a small station and controlling local probes. Can be manned by up to two Kerbals, though it isn't comfy.
-    #LOC_SSPX_sspx-core-125-1_tags = sspx base build center central connect construct (core hub nexus outpost statio reaction rotate wheel
+    #LOC_SSPX_sspx-core-125-1_tags = sspx base build center central connect construct (core hub nexus outpost statio reaction rotate wheel pier
     #LOC_SSPX_sspx-habitation-125-1_title = PTD-5 'Sunrise' Habitation Module
     #LOC_SSPX_sspx-habitation-125-1_description = This tiny habitation module has enough living space for a pair of Kerbals. It's not much, but it helps!
-    #LOC_SSPX_sspx-habitation-125-1_tags = sspx base contain outpost statio (stor tube can hab liv sleep
+    #LOC_SSPX_sspx-habitation-125-1_tags = sspx base contain outpost statio (stor tube can hab liv sleep sunrise
     #LOC_SSPX_sspx-utility-125-1_title = PTD-6 'Star' Utility Module
     #LOC_SSPX_sspx-utility-125-1_description = This crewed utility module has enough space for the station engineer to poke his head in every once in a while and hope things aren't going *too* wrong. Stores a goodly amount of electricity and RCS fuel to help stations get through those lean times.
-    #LOC_SSPX_sspx-utility-125-1_tags = sspx base contain outpost statio (stor tube fuel e/c ec battery
+    #LOC_SSPX_sspx-utility-125-1_tags = sspx base contain outpost statio (stor tube fuel e/c ec battery star
 
     #LOC_SSPX_sspx-airlock-125-1_title = SCATTER-1 Service Airlock
     #LOC_SSPX_sspx-airlock-125-1_description = After several incidents where unsuspecting Kerbalnauts unwittingly vented entire Hitchhiker pods to vacuum, engineers at Kerbalmax devised the Self-Contained Air Transport Tube for Excursion Rehearsal, which solves the problem by putting a second door between crew and space. It has seen limited uptake.
@@ -217,7 +217,7 @@ Localization
     #LOC_SSPX_sspx-attach-125-1_tags = sspx connect attach rad affix anchor mount secure
     #LOC_SSPX_sspx-cupola-125-1_title = PTD-C 'Porthole' Observation Window
     #LOC_SSPX_sspx-cupola-125-1_description = This little tin can seems like it would be a beautiful place to contemplate the stars, and it can be placed almost anywhere!
-    #LOC_SSPX_sspx-cupola-125-1_tags = sspx outpost base space stab statio view obs cupola
+    #LOC_SSPX_sspx-cupola-125-1_tags = sspx outpost base space stab statio view obs cupola porthole
 
     #LOC_SSPX_sspx-docking-125-1_title = Telescopic Clamp-O-Tron Docking Module
     #LOC_SSPX_sspx-docking-125-1_description = This docking connector has an integrated geared housing that allows it to extend outwards. Fully compatible with Clamp-O-Tron standard docking ports.
@@ -234,20 +234,20 @@ Localization
     // 1.25m inflatable parts
     #LOC_SSPX_sspx-inflatable-hab-125-1_title = PTD-E-2 'Eclair' Inflatable Habitation Module
     #LOC_SSPX_sspx-inflatable-hab-125-1_description = The large model PTD-series inflatable crew container allows a lot more living space for the same mass as a rigid container. Holds up to six crewmembers in relative comfort once expanded.
-    #LOC_SSPX_sspx-inflatable-hab-125-1_tags = sspx base contain outpost statio (stor tube inflat expand (hab liv
+    #LOC_SSPX_sspx-inflatable-hab-125-1_tags = sspx base contain outpost statio (stor tube inflat expand (hab liv eclair
     #LOC_SSPX_sspx-inflatable-hab-125-2_title = PTD-E-1A 'Volleyball' Inflatable Habitation Module
     #LOC_SSPX_sspx-inflatable-hab-125-2_description = The smallest inflatable ressembles a volleyball, and has no windows. Though this might not be the best for morale, you can't beat the savings! Holds up to three crew members in slightly cramped quarters once inflated... err, the marketing materials prefer 'expanded'.
-    #LOC_SSPX_sspx-inflatable-hab-125-2_tags = sspx base contain outpost statio (stor tube inflat beam expand (hab liv  ball dodge volley
+    #LOC_SSPX_sspx-inflatable-hab-125-2_tags = sspx base contain outpost statio (stor tube inflat beam expand (hab liv  ball dodge volley winston
 	  #LOC_SSPX_sspx-inflatable-hab-125-3_title = PTD-E-1B 'Winston' Inflatable Habitation Module
     #LOC_SSPX_sspx-inflatable-hab-125-3_description = A variation on the basic Winston, additional structural support has been removed in order to make the module vertically as well as horizontally expandable. Unfortunately, this makes the module a little less structurally sound and unable to be used as effectively as a structural component.
-    #LOC_SSPX_sspx-inflatable-hab-125-3_tags = sspx base contain outpost statio (stor tube inflat beam expand (hab liv ball dodge volley
+    #LOC_SSPX_sspx-inflatable-hab-125-3_tags = sspx base contain outpost statio (stor tube inflat beam expand (hab liv ball dodge volley winston
 
     #LOC_SSPX_sspx-inflatable-centrifuge-125-1_title = CTD-10 'Bagel' Inflatable Centrifuge Module
     #LOC_SSPX_sspx-inflatable-centrifuge-125-1_description = Check out this oddly shaped inflatable space bread! Not suitable for consumption. However, once expanded to its 8 metre diameter, it can provide a simulacrum of gravity for those inside of it - up to 0.25g when spinning. Holds up to six Kerbals.
-    #LOC_SSPX_sspx-inflatable-centrifuge-125-1_tags = sspx base contain outpost statio (stor tube inflat (hab liv expand donut spin centrifuge wheel gravity
+    #LOC_SSPX_sspx-inflatable-centrifuge-125-1_tags = sspx base contain outpost statio (stor tube inflat (hab liv expand donut spin centrifuge wheel gravity bagel
     #LOC_SSPX_sspx-inflatable-centrifuge-125-2_title = CTD-5 'Doughnut' Compact Inflatable Centrifuge Module
     #LOC_SSPX_sspx-inflatable-centrifuge-125-2_description = A compact inflatable centrifuge, this model is distinctly cramped and uncomfortable. It does fit in a small space, however, so could be perfect for those early spacecraft. A diameter of 5 metres is possible when fully inflated, providing up to 0.1g of gravity. Holds up to four Kerbals.
-    #LOC_SSPX_sspx-inflatable-centrifuge-125-2_tags = sspx base contain outpost statio (stor tube inflat (hab liv expand donut spin centrifuge wheel gravity
+    #LOC_SSPX_sspx-inflatable-centrifuge-125-2_tags = sspx base contain outpost statio (stor tube inflat (hab liv expand donut spin centrifuge wheel gravity doughnut donut
 
     // Radial cargo containers
     #LOC_SSPX_sspx-cargo-container-radial-small-1_title = KRDA-O800 Cargo Container

--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-CLS.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-CLS.cfg
@@ -423,7 +423,7 @@ MODULE
     passableWhenSurfaceAttached = true
   }
 }
-@PART[sspx-habitation-375-3]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+@PART[sspx-lab-375-1]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
 {
   MODULE
   {

--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-KeepFit.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-KeepFit.cfg
@@ -1,0 +1,39 @@
+// by default, utility spaces are cramped
+@PART[sspx-airlock-25-1,sspx-utility-125-1,sspx-airlock-125-1]:AFTER[KeepFit]
+{
+    MODULE
+    {
+        name = KeepFitPartModule
+		strActivityLevel = CRAMPED
+    }
+}
+
+// Work spaces, small cupolas, and 'minimalist' habs are comfy
+@PART[sspx-lab-375-1,sspx-habitation-375-3,sspx-greenhouse-375-1,sspx-cupola-375-1,sspx-core-375-1,sspx-aquaculture-375-1,sspx-greenhouse-25-1,sspx-core-25-1,sspx-habitation-125-1,sspx-cupola-125-1,sspx-core-125-1]:AFTER[KeepFit]
+{
+    MODULE
+    {
+        name = KeepFitPartModule
+		strActivityLevel = COMFY
+    }
+}
+
+// Large cupolas and inflatable or dedicated crew habitats are neutral
+@PART[sspx-habitation-375-2,sspx-observation-25-1,sspx-habitation-25-1,sspx-inflatable-hab-25-2,sspx-inflatable-hab-25-1,sspx-inflatable-hab-125-3,sspx-inflatable-hab-125-2,sspx-inflatable-hab-125-1]:AFTER[KeepFit]
+{
+    MODULE
+    {
+        name = KeepFitPartModule
+		strActivityLevel = NEUTRAL
+    }
+}
+
+// Centrifuges and giant habs are exercising spaces
+@PART[sspx-habitation-375-1,sspx-expandable-centrifuge-375-2,sspx-expandable-centrifuge-375-1,sspx-inflatable-centrifuge-25-1,sspx-inflatable-centrifuge-125-2,sspx-inflatable-centrifuge-125-1]:AFTER[KeepFit]
+{
+    MODULE
+    {
+        name = KeepFitPartModule
+		strActivityLevel = EXERCISING
+    }
+}


### PR DESCRIPTION
New tags: Searching for `winston` will not find a part whose title is `'winston'` (and so on), so I've added part nicknames to their tags to make them easier to find.  (Stock engines already do this.)

KeepFit patch: a health mod that I use.  Centrifuges and giant habs are good for Kerbal health, cramped utility spaces not so much.

CLS patch: the 3.75 m hab definition was duplicated, and the 3.75m lab definition was omitted.