### PR TITLE
Fix typo in sspx-greenhouse-25-1 tags attribute

### DIFF
--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-25/sspx-greenhouse-25-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-25/sspx-greenhouse-25-1.cfg
@@ -69,7 +69,7 @@ PART
 	// --- internal setup ---
 	CrewCapacity = 2
 
-	tags = #LOC_SSPX_sspx-greenhouse-25-1-25_tags
+	tags = #LOC_SSPX_sspx-greenhouse-25-1_tags
 
 	INTERNAL
 	{


### PR DESCRIPTION
Using a nonexistent localization key meant the part didn't get any tags.  (And lack of the "cck-lifesupport" tag additionally meant that it didn't appear in the CCK "Life Support" category.)