### PR TITLE
Minor EC consumption adjustment on PXL-E 'Mercury'

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-USILS.cfg
@@ -552,7 +552,7 @@
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
-			Ratio = 48.525
+			Ratio = 56.4
 		}
 	}
 }


### PR DESCRIPTION
- Increase EC consumption on PXL-E 'Mercury' due to the amount of gravity generation at 0.6g instead of 0.5g