### PR TITLE
Treat habitats as under-equipped EL workshops

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-EL-Extras.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-EL-Extras.cfg
@@ -9,6 +9,7 @@
 	{
 		name = ELWorkshop
 		ProductivityFactor = 0.8
+		IgnoreCrewCapacity = true	// Needed for variable-capacity parts
 	}
 }
 
@@ -19,5 +20,6 @@
 	{
 		name = ELWorkshop
 		ProductivityFactor = 0.8
+		IgnoreCrewCapacity = true	// Needed for variable-capacity parts
 	}
 }


### PR DESCRIPTION
This PR reduces the productivity factor of the Extraplanetary Launchpads workshops introduced in #140  from its previous range of 1.5-9.0 to a flat value of 0.8. I believe the factor should be this low for two reasons.

The first is game balance. Extraplanetary Launchpads provides a 15-ton workshop that can house 10 kerbals with a productivity factor of 5.0, for an efficiency of 3.3 kerbal-hours per hour per ton. All the affected habitats are lighter, yet many have similar or greater crew capacities. With the current patch, most of the SSPX habitats provide more labor per part mass than the EL workshop (up to 16.6 kerbal-hours/hour/ton), in addition to their other impressive capabilities. With the new version, players will still have a reason to include dedicated workshop parts on stations instead of just using a habitat for everything.

The second reason is thematic consistency, both with Extraplanetary Launchpads and with other mods that support it. EL marks any workshop with a productivity factor >= 1 as "fully equipped", expanding the set of kerbals who can work there and using different productivity formulas ([EL manual](http://taniwha.org/~bill/EL_Manual.pdf), section 2.3). The explanation of the distinction between fully-equipped and under-equipped workshops (section 2.4) makes it clear that fully equipped status represents a space that's designed for construction work, and that generic crew spaces should not have it.

Setting the productivity to 0.8 will make the SSPX habitats more effective workspaces than other non-workshop parts, as in the original patch, while still rewarding players for going to the trouble to launch (or build!) a specialized workshop.

@LouisCyfer, please let me know if you approve. Thanks!