### PR TITLE
Missing "}" closing ModuleB9PartSwitch in 2.5m inflatable habitats

### DIFF
--- a/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-25/sspx-inflatable-hab-25-1.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-25/sspx-inflatable-hab-25-1.cfg
@@ -176,6 +176,7 @@ PART
       primaryColor = #ffffff
       secondaryColor = #ffffff
 		}
+	}
 	MODULE
 	{
 		name = ModuleDeployableHabitat

--- a/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-25/sspx-inflatable-hab-25-2.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Extendable/extendable-25/sspx-inflatable-hab-25-2.cfg
@@ -176,6 +176,7 @@ PART
       primaryColor = #ffffff
       secondaryColor = #ffffff
 		}
+	}
 	MODULE
 	{
 		name = ModuleScienceExperiment


### PR DESCRIPTION
The missing bracket nests ModuleDeployableHabitat within ModuleB9PartSwitch.(Kerbalism/Kerbalism#528)