### PR TITLE
Add switchable tanks to Asylum shelter

### DIFF
--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-375/sspx-habitation-375-3.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-375/sspx-habitation-375-3.cfg
@@ -290,7 +290,7 @@ PART
 		SUBTYPE:NEEDS[CryoTanks]
 		{
 			name = LH2
-			tankType = SSPX_Shelter_LH2
+			tankType = LH2
 			title = #LOC_CryoTanks_switcher_fuel_lh2
 			addedMass = -0.8
 			addedCost = -1800
@@ -298,7 +298,7 @@ PART
 		SUBTYPE:NEEDS[CryoTanks]
 		{
 			name = LH2O
-			tankType = SSPX_Shelter_LH2O
+			tankType = LH2O
 			title = #LOC_CryoTanks_switcher_fuel_lh2ox
 			addedMass = -0.8
 			addedCost = -1800

--- a/GameData/StationPartsExpansionRedux/Parts/Rigid/station-375/sspx-habitation-375-3.cfg
+++ b/GameData/StationPartsExpansionRedux/Parts/Rigid/station-375/sspx-habitation-375-3.cfg
@@ -76,12 +76,6 @@ PART
 
 	RESOURCE
 	{
-		name = MonoPropellant
-		amount = 1500
-		maxAmount = 1500
-	}
-	RESOURCE
-	{
 		name = ElectricCharge
 		amount = 750
 		maxAmount = 750
@@ -251,6 +245,83 @@ PART
 		alphaCurve
 		{
 			key = 0 1
+		}
+	}
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = tankSwitch
+		switcherDescription = Tanks //add localization
+		baseVolume = 1500
+		switchInFlight = False
+		affectDragCubes = False
+		SUBTYPE
+		{
+			name = MonoPropellant
+			tankType = SSPX_Shelter_Monopropellant
+			title = #autoLOC_501002
+			addedMass = -0.8
+			addedCost = -1800
+		}
+		SUBTYPE
+		{
+			name = LFO
+			tankType = SSPX_Shelter_LFO
+			title = LF/Ox //add localization
+			addedMass = -0.8
+			addedCost = -1800
+		}
+		SUBTYPE
+		{
+			name = LiquidFuel
+			tankType = SSPX_Shelter_LiquidFuel
+			title = #autoLOC_500999
+			addedMass = -0.8
+			addedCost = -1800
+		}
+		SUBTYPE
+		{
+			name = Oxidizer
+			tankType = SSPX_Shelter_Oxidizer
+			title = #autoLOC_501000
+			addedMass = -0.8
+			addedCost = -1800
+		}
+		SUBTYPE:NEEDS[CryoTanks]
+		{
+			name = LH2
+			tankType = SSPX_Shelter_LH2
+			title = #LOC_CryoTanks_switcher_fuel_lh2
+			addedMass = -0.8
+			addedCost = -1800
+		}
+		SUBTYPE:NEEDS[CryoTanks]
+		{
+			name = LH2O
+			tankType = SSPX_Shelter_LH2O
+			title = #LOC_CryoTanks_switcher_fuel_lh2ox
+			addedMass = -0.8
+			addedCost = -1800
+		}
+		SUBTYPE:NEEDS[CommunityResourcePack]
+		{
+			name = Water
+			tankType = SSPX_Shelter_Water
+			title = #LOC_SSPX_Switcher_Cargo_Water
+			addedMass = -0.8
+			addedCost = -1800
+		}
+	}
+	MODULE:NEEDS[CryoTanks]
+	{
+		name = ModuleCryoTank
+		CoolingEnabled = False
+		BOILOFFCONFIG
+		{
+			FuelName = LqdHydrogen
+			// in % per hr
+			BoiloffRate = 0.05
+			CoolingCost = 0.09
 		}
 	}
 }

--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-B9TankTypes-Shelter.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-B9TankTypes-Shelter.cfg
@@ -1,0 +1,93 @@
+B9_TANK_TYPE
+{
+	name = SSPX_Shelter_Monopropellant
+	tankMass = 0.00053333333 //based on stock FL-R1 2.5m RCS tank
+	tankCost = 0
+	RESOURCE
+	{
+		name = MonoPropellant
+		unitsPerVolume = 1
+	}
+}
+
+B9_TANK_TYPE
+{
+	name = SSPX_Shelter_LFO
+	tankMass = 0.000625
+	tankCost = 0
+	RESOURCE
+  {
+    name = LiquidFuel
+    unitsPerVolume = 0.45
+  }
+  RESOURCE
+  {
+    name = Oxidizer
+    unitsPerVolume = 0.55
+  }
+}
+
+B9_TANK_TYPE
+{
+	name = SSPX_Shelter_LiquidFuel
+	tankMass = 0.000625
+	tankCost = 0
+	RESOURCE
+  {
+    name = LiquidFuel
+    unitsPerVolume = 1
+  }
+}
+
+B9_TANK_TYPE
+{
+	name = SSPX_Shelter_Oxidizer
+	tankMass = 0.000625
+	tankCost = 0
+	RESOURCE
+  {
+    name = Oxidizer
+    unitsPerVolume = 1
+  }
+}
+
+B9_TANK_TYPE:NEEDS[CryoTanks]
+{
+	name = SSPX_Shelter_LH2
+	tankMass = 0.00010627500
+	tankCost = 0
+	RESOURCE
+  {
+    name = LqdHydrogen
+    unitsPerVolume = 7.5
+  }
+}
+
+B9_TANK_TYPE:NEEDS[CryoTanks]
+{
+	name = SSPX_Shelter_LH2O
+	tankMass = 0.000278904
+	tankCost = 0
+	RESOURCE
+  {
+    name = LqdHydrogen
+    unitsPerVolume = 4.995
+  }
+  RESOURCE
+  {
+    name = Oxidizer
+    unitsPerVolume = 0.333
+  }
+}
+
+B9_TANK_TYPE:NEEDS[CommunityResourcePack]
+{
+	name = SSPX_Shelter_Water
+	tankMass = 0.000625 // Tentative
+	tankCost = 0
+	RESOURCE
+	{
+		name = Water
+		unitsPerVolume = 5
+	}
+}

--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-B9TankTypes-Shelter.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-B9TankTypes-Shelter.cfg
@@ -51,35 +51,6 @@ B9_TANK_TYPE
   }
 }
 
-B9_TANK_TYPE:NEEDS[CryoTanks]
-{
-	name = SSPX_Shelter_LH2
-	tankMass = 0.00010627500
-	tankCost = 0
-	RESOURCE
-  {
-    name = LqdHydrogen
-    unitsPerVolume = 7.5
-  }
-}
-
-B9_TANK_TYPE:NEEDS[CryoTanks]
-{
-	name = SSPX_Shelter_LH2O
-	tankMass = 0.000278904
-	tankCost = 0
-	RESOURCE
-  {
-    name = LqdHydrogen
-    unitsPerVolume = 4.995
-  }
-  RESOURCE
-  {
-    name = Oxidizer
-    unitsPerVolume = 0.333
-  }
-}
-
 B9_TANK_TYPE:NEEDS[CommunityResourcePack]
 {
 	name = SSPX_Shelter_Water


### PR DESCRIPTION
Per #222. Tank types for the 3.75m Asylum part have been defined and added as switchable subtypes for the following contents: Monopropellent, LFO, Liquid Fuel, Oxidizer, Liquid Hydrogen, Hydrolox, and Water. CryoTanks has been specified as a dependency for the LqdHydrogen-based options and CRP for Water. 

Testing in the VAB seems to indicate that everything is working as expected, including mass and cost that match the prior Monoprop-only implementation of the Asylum. There are a couple of spots where display names have been hard-coded rather than localized; these are marked as such with comments.