### PR TITLE
Add missing Snacks soil recyclers & storage

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-Snacks.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-Snacks.cfg
@@ -1,4 +1,4 @@
-// add general standard SoilRecycler to selected parts
+// add general standard SoilRecycler and Soil capacity to selected parts
 @PART[sspx-greenhouse-*,sspx-inflatable-centrifuge-*,sspx-expandable-centrifuge-*,sspx-habitation-*,sspx-inflatable-hab-*,sspx-aquaculture-375-1,sspx-utility-125-1]:NEEDS[Snacks]
 {
 	MODULE
@@ -46,6 +46,17 @@
 		mtbf = 100 
 		monitorConverters = true //WARNING: this is a performance hit.
 	}
+
+	// Note, Snacks mod adds Snacks capacity to crewed parts automatically.
+	// Soil capacity is not automatic since only parts with recyclers
+	// should have it.
+	RESOURCE
+	{
+		name = Soil
+		amount = 0
+		maxAmount = 50
+		@maxAmount *= #$../CrewCapacity$
+	}
 }
 // fine tuning starts here:
 // centrifuges
@@ -58,6 +69,14 @@
 		// since centrifuges don't have crew capacity we need to adapt
 		@RecyclerCapacity *= #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
 	}
+
+	@RESOURCE[Soil]
+	{
+		// rebase to default
+		@maxAmount = 50
+		// since centrifuges don't have crew capacity we need to adapt
+		@maxAmount *= #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+	}
 }
 // non-centrifuge inflatable habs
 @PART[sspx-inflatable-hab-*]:HAS[@MODULE[SoilRecycler]]:NEEDS[Snacks]:FINAL
@@ -68,6 +87,14 @@
 		@RecyclerCapacity = 1
 		// since inflatables don't have crew capacity we need to adapt
 		@RecyclerCapacity *= #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
+	}
+
+	@RESOURCE[Soil]
+	{
+		// rebase to default
+		@maxAmount = 50
+		// since inflatables don't have crew capacity we need to adapt
+		@maxAmount *= #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
 	}
 }
 
@@ -120,13 +147,10 @@
 			FlowMode = STAGE_PRIORITY_FLOW
 		}
 	}
-	// add soil only for greenhouses (maxAmount = 100 * CrewCapacity)
-	RESOURCE
+	// Greenhouses hold extra Soil (compared to habs)
+	@RESOURCE[Soil]
 	{
-		name = Soil
-		amount = 0
-		maxAmount = 100
-		@maxAmount *= #$../CrewCapacity$
+		@maxAmount *= 2
 	}
 }
 // sspx-greenhouse-375-1: 30% boost EC usage and Snacks output in both modules (SoilRecycler, SnackProcessor)

--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-Snacks.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-Snacks.cfg
@@ -1,5 +1,5 @@
 // add general standard SoilRecycler to selected parts
-@PART[sspx-greenhouse-*,sspx-inflatable-centrifuge-*,sspx-expandable-centrifuge-*,sspx-habitation-*,sspx-aquaculture-375-1,sspx-utility-125-1]:NEEDS[Snacks]
+@PART[sspx-greenhouse-*,sspx-inflatable-centrifuge-*,sspx-expandable-centrifuge-*,sspx-habitation-*,sspx-inflatable-hab-*,sspx-aquaculture-375-1,sspx-utility-125-1]:NEEDS[Snacks]
 {
 	MODULE
 	{
@@ -57,6 +57,17 @@
 		@RecyclerCapacity = 1
 		// since centrifuges don't have crew capacity we need to adapt
 		@RecyclerCapacity *= #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+	}
+}
+// non-centrifuge inflatable habs
+@PART[sspx-inflatable-hab-*]:HAS[@MODULE[SoilRecycler]]:NEEDS[Snacks]:FINAL
+{
+	@MODULE[SoilRecycler]
+	{
+		// rebase to default
+		@RecyclerCapacity = 1
+		// since inflatables don't have crew capacity we need to adapt
+		@RecyclerCapacity *= #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
 	}
 }
 
@@ -145,7 +156,7 @@
 	}
 }
 // add extra-tags only when SoilRecycler module is found!
-@PART[sspx-inflatable-centrifuge-*,sspx-expandable-centrifuge-*,sspx-habitation-*,sspx-aquaculture-375-1,sspx-utility-125-1]:HAS[@MODULE[SoilRecycler]]:NEEDS[Snacks]:FINAL
+@PART[sspx-inflatable-centrifuge-*,sspx-expandable-centrifuge-*,sspx-habitation-*,sspx-inflatable-hab-*,sspx-aquaculture-375-1,sspx-utility-125-1]:HAS[@MODULE[SoilRecycler]]:NEEDS[Snacks]:FINAL
 {
 	// Adds suffix
 	@tags ^= :$: cck-lifesupport:


### PR DESCRIPTION
The "Snacks!" life-support mod adds a recycler module to (among other things) the stock Hitchhiker, and SSPXR follows suit by adding recyclers to other hab parts.  However, some parts seem to have been missed: the patch applied to the rigid habs and inflatable/extendable centrifuge habs, but not to the inflatable non-centifuge habs.