### PR TITLE
Don't shutdown SoilRecycler when output is full

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-Snacks.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-Snacks.cfg
@@ -7,7 +7,7 @@
 		ConverterName = #LOC_SSPXR_Switcher_SoilRecycler_ConverterName // #LOC_SSPXR_Switcher_SoilRecycler_ConverterName = Soil Recycler
 		StartActionName = #LOC_SSPXR_Switcher_SoilRecycler_StartActionName // #LOC_SSPXR_Switcher_SoilRecycler_StartActionName = Start Soil Recycler
 		StopActionName = #LOC_SSPXR_Switcher_SoilRecycler_StopActionName // #LOC_SSPXR_Switcher_SoilRecycler_StopActionName = Stop Soil Recycler
-		AutoShutdown = true // default false (snacks shouldn't be wasted!)
+		AutoShutdown = false
 		GeneratesHeat = false
 		UseSpecialistBonus = true
 		ExperienceEffect = ScienceSkill


### PR DESCRIPTION
The `DumpExcess = false` in the `OUTPUT_RESOURCE` block is enough to make the recycler stop consuming input resources when it has nowhere to put the output.  With `AutoShutdown = true`, the recycler will turn off entirely when the output is full, so that it won't do any more recycling until the player manually turns it on again.  Without `AutoShutdown`, it'll just pause, and automatically resume whenever there's room for more output.  The latter seems like the safer choice, and it's what the Snacks mod does with the recyclers that it adds to stock parts, so I've changed the patch here to match.