### PR TITLE
Material kit requirement for inflatables, Centrifuge tech node changes

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-CTT.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-CTT.cfg
@@ -5,11 +5,11 @@
 // ------------
 @PART[sspx-inflatable-centrifuge-125-1]:NEEDS[CommunityTechTree]
 {
-  @TechRequired = shortTermHabitation
+  @TechRequired = longTermHabitation
 }
 @PART[sspx-inflatable-centrifuge-125-2]:NEEDS[CommunityTechTree]
 {
-  @TechRequired = shortTermHabitation
+  @TechRequired = longTermHabitation
 }
 
 // 2.5m rigid
@@ -40,7 +40,7 @@
 // ------------
 @PART[sspx-inflatable-centrifuge-25-1]:NEEDS[CommunityTechTree]
 {
-  @TechRequired = shortTermHabitation
+  @TechRequired = longTermHabitation
 }
 @PART[sspx-inflatable-hab-25-1]:NEEDS[CommunityTechTree]
 {
@@ -91,11 +91,11 @@
 // ------------
 @PART[sspx-expandable-centrifuge-375-1]:NEEDS[CommunityTechTree]
 {
-  @TechRequired = longTermHabitation
+  @TechRequired = colonization
 }
 @PART[sspx-expandable-centrifuge-375-2]:NEEDS[CommunityTechTree]
 {
-  @TechRequired = longTermHabitation
+  @TechRequired = colonization
 }
 
 // Ground Bases

--- a/SSPXR-MKS-Extras.cfg
+++ b/SSPXR-MKS-Extras.cfg
@@ -1,0 +1,317 @@
+//MKS Extra patch
+// Authored by KSP forum users JadeOfMaar and Pulsar 
+
+//Resources needed for deploying modules
+@PART:HAS[@MODULE[ModuleDeployableCentrifuge]]:NEEDS[MKS|GroundConstruction,!Kerbalism]
+{
+	DeployedMass = #$mass$
+	@mass *= 0.4
+	
+	@MODULE[ModuleDeployableCentrifuge]
+	{
+		DeployResource = MaterialKits
+		DeployResourceAmount = #$../DeployedMass$
+		@DeployResourceAmount *= 600
+		%DeployedMassModifier = #$../DeployedMass$
+		@DeployedMassModifier *= 0.6
+	}
+}
+@PART:HAS[@MODULE[ModuleDeployableHabitat]]:NEEDS[MKS|GroundConstruction,!Kerbalism]
+{
+	DeployedMass = #$mass$
+	@mass *= 0.6
+	
+	@MODULE[ModuleDeployableHabitat]
+	{
+		DeployResource = MaterialKits
+		DeployResourceAmount = #$../DeployedMass$
+		@DeployResourceAmount *= 400
+		%DeployedMassModifier = #$../DeployedMass$
+		@DeployedMassModifier *= 0.4
+	}
+}
+
+//Enabling all inflatables to be deployed by all types of crew
+@PART:HAS[@MODULE[ModuleDeployableCentrifuge]]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	@MODULE[ModuleDeployableCentrifuge]
+	{
+		@CrewSkillNeeded =
+	}
+}
+@PART:HAS[@MODULE[ModuleDeployableHabitat]]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	@MODULE[ModuleDeployableHabitat]
+	{
+		@CrewSkillNeeded =
+	}
+}
+
+// Station cores
+// 2.5m core, 3.75m cupola
+// PPD-8 'Wharf', PXL-9 Astrogation
+@PART[sspx-core-25-1|sspx-cupola-375-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+	MODULE
+	{
+		name = ModulePowerDistributor
+	}
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+}
+
+// 3.75m core
+// PXL-10 'Harbour'
+@PART[sspx-core-375-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+	MODULE
+	{
+		name = ModulePowerDistributor
+	}
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+}
+
+// 1.25m core
+// PTD-8R 'Pier'
+@PART[sspx-core-125-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+	MODULE
+	{
+		name = ModulePowerDistributor
+	}
+	MODULE
+	{
+		name = ModulePowerCoupler
+	}
+}
+
+// 1.25m cupola
+// PTD-C Observation Window
+@PART[sspx-cupola-125-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../CrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// 1.25m hab
+// PTD-5 'Sunrise'
+@PART[sspx-habitation-25-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../CrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// 1.25m util
+// PTD-6 'Star'
+@PART[sspx-utility-125-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+}
+
+// Inflatables 1.25m 
+// PTD-E-1A, PTD-E-1B 'Winston'
+@PART[sspx-inflatable-hab-125-2|sspx-inflatable-hab-125-3]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// PTD-E-2 'Eclair'
+@PART[sspx-inflatable-hab-125-1]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// Centrifuges 1.25m
+// CTD-10, CTD-5
+@PART[sspx-inflatable-centrifuge-125-1,sspx-inflatable-centrifuge-125-2]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// Rigid hab 2.5m
+// PPD-20 'Shanty'
+@PART[sspx-habitation-25-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../CrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// Observatory 2.5m
+// PPD-24 'Panorama'
+@PART[sspx-observation-25-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		name = MKSModule
+		workSpace = 0
+		livingSpace = #$../CrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// Greenhouse 2.5m
+// PPD-F412M
+@PART[sspx-greenhouse-25-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+}
+
+// Greenhouse 3.75m
+//PXL-R4NCH-3R
+@PART[sspx-greenhouse-375-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+}
+
+// BotanySkill requirement for greenhouses
+@PART[sspx-greenhouse-25-1|sspx-greenhouse-375-1]:NEEDS[USILifeSupport,MKS]:AFTER[StationPartsExpansionRedux]
+{
+	@MODULE[ModuleResourceConverter_USI]
+	{
+		UseSpecialistBonus = true
+		SpecialistEfficiencyFactor = 0.2
+		SpecialistBonusBase = 0.05
+		ExperienceEffect = BotanySkill
+		Efficiency = 1
+	}
+}
+
+// Aquaculture 2.5m
+@PART[sspx-aquaculture-375-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+}
+
+// Inflatables 2.5m
+// PFD-A, PFD-B
+@PART[sspx-inflatable-hab-25-1,sspx-inflatable-hab-25-2]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../MODULE[ModuleDeployableHabitat]/DeployedCrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+}
+
+// Centrifuges 2.5m
+// PFD-C
+@PART[sspx-inflatable-centrifuge-25-1]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// Centrifuges 3.75m
+// PXL-E 'Mercury', PXL-F 'Pilgrim'
+@PART[sspx-expandable-centrifuge-375-1,sspx-expandable-centrifuge-375-2]:NEEDS[MKS,!Kerbalism]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+		livingSpace = #$../MODULE[ModuleDeployableCentrifuge]/DeployedCrewCapacity$
+		hasGenerators = false
+	}
+	MODULE
+	{
+		name = SpaceAcademy
+	}
+}
+
+// Rigid habs 3.75m
+// PXL-1 'Hostel', PXL-2 'Shelter', PXL-3 'Asylum'
+@PART[sspx-habitation-375-1,sspx-habitation-375-2,sspx-habitation-375-3]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = 0
+		livingSpace = #$../CrewCapacity$
+		hasGenerators = false
+	}
+}
+
+// Science lab
+// PXL-2 'Fate'
+@PART[sspx-lab-375-1]:NEEDS[MKS]:AFTER[MKS]
+{
+	%MODULE[MKSModule]
+	{
+		workSpace = #$../CrewCapacity$
+		livingSpace = 0
+		hasGenerators = false
+	}
+}


### PR DESCRIPTION
Adjusted the pre/post-deployment weights and materials kits requirements for inflatables. This is now scaled so that a 1.25m "volleyball" inflatable can be deployed with the 600MKs in the 1.25m Kontainer.

Moved small/inflatable centrifuges from short term habitation to long term (short term hab seems to me to be a tech level of at or just above ISS, artificial gravity is more advanced and more relevant to long term habitation), larger rigid centrifuges from long term to colonization. This separates parts the fill the same niche from the same tech level.