### PR TITLE
Create SSPXR-B9PartSwitch-Plurals.cfg

### DIFF
--- a/GameData/StationPartsExpansionRedux/Patches/SSPXR-B9PartSwitch-Plurals.cfg
+++ b/GameData/StationPartsExpansionRedux/Patches/SSPXR-B9PartSwitch-Plurals.cfg
@@ -1,0 +1,26 @@
+// This patch adds in a descriptor for the subtypes within the PAW to easily distinguish the types of switches.
+
+@PART[sspx-*]:HAS[@MODULE[ModuleB9PartSwitch]]:AFTER[StationPartsExpansionRedux]
+{
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[endcapSwitch]]
+	{
+		%switcherDescriptionPlural = Upper End Caps
+	}
+	
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[endcapSwitchLower]]
+	{
+		%switcherDescriptionPlural = Lower End Caps
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[endcapSwitch2]]
+	{
+		%switcherDescriptionPlural = Lower End Caps
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[typeSwitch]]
+	{
+		%switcherDescriptionPlural = Part Variants
+	}	
+	@MODULE[ModuleB9PartSwitch]:NEEDS[StationPartsExpansionMetal]:HAS[#moduleID[surfaceSwitch]]
+	{
+		%switcherDescriptionPlural = Surface Materials
+	}
+}


### PR DESCRIPTION
This patches in B9 Plurals to help make the subtypes easier to distinguish in PAW.