### PR TITLE
Fix Chinese Localization Error

### DIFF
--- a/GameData/StationPartsExpansionRedux/Localization/zh-cn.cfg
+++ b/GameData/StationPartsExpansionRedux/Localization/zh-cn.cfg
@@ -459,7 +459,7 @@ Localization
     #LOC_SSPX_Switcher_Cargo_Lead = 铅
     #LOC_SSPX_Switcher_Cargo_Snacks = 零食
     #LOC_SSPX_Switcher_Cargo_Soil = 土壤
-    #LOC_SSPX_Switcher_Cargo_RocketParts = 残骸
+    #LOC_SSPX_Switcher_Cargo_RocketParts = 火箭零件
     #LOC_SSPX_Switcher_Cargo_MetalOre = 金属矿石
     #LOC_SSPX_Switcher_Cargo_ScrapMetal = 废金属
     #LOC_SSPX_Switcher_Cargo_Metal = 合金


### PR DESCRIPTION
RocketParts should be translate to "火箭零件"(rocket parts) instead of "残骸"(scrap, wreckage).