### PR TITLE
Multi-hosting for StationPartsExpansionRedux in CKAN

### DIFF
--- a/CKAN/StationPartsExpansionRedux-IVAs.netkan
+++ b/CKAN/StationPartsExpansionRedux-IVAs.netkan
@@ -1,25 +1,21 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "StationPartsExpansionRedux-IVAs",
-    "name":         "Stockalike Station Parts Expansion Redux - Internal Spaces",
-    "$kref":        "#/ckan/spacedock/1682",
-    "$vref"               : "#/ckan/ksp-avc/StationPartsExpansionRedux.version",
-    "abstract": "Adds IVA spaces to Stockalike Station Parts Expansion Redux. Without this, IVA spaces will appear as blank voids",
-    "author": "Nertea (Chris Adderley)",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/170211-*",
-        "repository": "https://github.com/post-kerbin-mining-corporation/StationPartsExpansionRedux"
-    },
-    "depends": [
-        { "name": "StationPartsExpansionRedux"   },
-        { "name": "NearFutureProps" }
-    ],
-    "supports" : [
-        { "name" : "RasterPropMonitor-Core" }
-    ],
-    "install": [ {
-        "find":       "StationPartsExpansionReduxIVAs",
-        "install_to": "GameData"
-    } ]
-}
+identifier: StationPartsExpansionRedux-IVAs
+$kref: '#/ckan/github/post-kerbin-mining-corporation/StationPartsExpansionRedux'
+$vref: '#/ckan/ksp-avc/StationPartsExpansionRedux.version'
+---
+identifier: StationPartsExpansionRedux-IVAs
+name: Stockalike Station Parts Expansion Redux - Internal Spaces
+$kref: '#/ckan/spacedock/1682'
+$vref: '#/ckan/ksp-avc/StationPartsExpansionRedux.version'
+abstract: >-
+  Adds IVA spaces to Stockalike Station Parts Expansion Redux. Without this, IVA
+  spaces will appear as blank voids
+author: Nertea (Chris Adderley)
+license: restricted
+depends:
+  - name: StationPartsExpansionRedux
+  - name: NearFutureProps
+supports:
+  - name: RasterPropMonitor-Core
+install:
+  - find: StationPartsExpansionReduxIVAs
+    install_to: GameData

--- a/CKAN/StationPartsExpansionRedux.netkan
+++ b/CKAN/StationPartsExpansionRedux.netkan
@@ -1,32 +1,21 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "StationPartsExpansionRedux",
-    "name":         "Stockalike Station Parts Expansion Redux",
-    "$kref":        "#/ckan/spacedock/1682",
-    "$vref"               : "#/ckan/ksp-avc/StationPartsExpansionRedux.version",
-    "abstract": "A plethora of new station parts in several size classes.",
-    "author": "Nertea (Chris Adderley)",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/170211-*",
-        "repository": "https://github.com/ChrisAdderley/StationPartsExpansionRedux"
-    },
-    "depends": [
-        { "name": "ModuleManager"   },
-        { "name": "B9PartSwitch"    }
-    ],
-    "suggests" : [
-        { "name" : "CommunityTechTree" },
-        { "name" : "StationPartsExpansionRedux-IVAs" }
-    ],
-    "conflicts" : [
-        { "name" : "StationPartsExpansionRedux-Metal" }
-    ],
-    "supports" : [
-        { "name" : "ConnectedLivingSpace" }
-    ],
-    "install": [ {
-        "find":       "StationPartsExpansionRedux",
-        "install_to": "GameData"
-    } ]
-}
+identifier: StationPartsExpansionRedux
+$kref: '#/ckan/github/post-kerbin-mining-corporation/StationPartsExpansionRedux'
+$vref: '#/ckan/ksp-avc/StationPartsExpansionRedux.version'
+---
+identifier: StationPartsExpansionRedux
+name: Stockalike Station Parts Expansion Redux
+$kref: '#/ckan/spacedock/1682'
+$vref: '#/ckan/ksp-avc/StationPartsExpansionRedux.version'
+abstract: A plethora of new station parts in several size classes.
+author: Nertea (Chris Adderley)
+license: restricted
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+suggests:
+  - name: CommunityTechTree
+  - name: StationPartsExpansionRedux-IVAs
+conflicts:
+  - name: StationPartsExpansionRedux-Metal
+supports:
+  - name: ConnectedLivingSpace


### PR DESCRIPTION
Hi @ChrisAdderley,

I noticed this mod was only downloading from SpaceDock, which can be slow for some users, so here are some edits to improve that:

- Syntax updated from JSON to YAML for easier maintenance
- Get the download from both GitHub and SpaceDock, defaulting to GitHub
- Get `resources.repository` from the GitHub reference
- Get `resources.homepage` from SpaceDock's website link (took the liberty of setting this to the forum thread on SpaceDock)
- Use the default install stanza since the identifier matches the folder name (not done for the IVAs because the identifier has an extra `-` that isn't in the folder name)
- `spec_version` is optional and will be auto-calculated by the bot as needed

After this, users will get the GitHub link by default, or they can use the CKAN settings to opt in to SpaceDock.

Cheers!
