### PR TITLE
Fix a wrong zh-cn translation

### DIFF
--- a/GameData/StationPartsExpansionRedux/Localization/zh-cn.cfg
+++ b/GameData/StationPartsExpansionRedux/Localization/zh-cn.cfg
@@ -718,7 +718,7 @@ Localization
     #LOC_SSPX_ActionRetractProjectors = 收回投射器
     #LOC_SSPX_ActionToggleProjectors = 开关投射器
 
-    #LOC_SSPX_Science_VisualScan_Action_Name = 裸眼观测报告
+    #LOC_SSPX_Science_VisualScan_Action_Name = 目视观测
     #LOC_SSPX_Science_VisualScan_Action_Reset = 重置报告
     #LOC_SSPX_Science_VisualScan_Action_Review = 查看报告
 
@@ -730,7 +730,7 @@ Localization
     #LOC_SSPX_Science_FishStudy_Action_Reset = 丢弃标本
     #LOC_SSPX_Science_FishStudy_Action_Collect = 收集标本
 
-    #LOC_SSPX_Science_TelescopeObservation_Action_Name = 观测本地天空
+    #LOC_SSPX_Science_TelescopeObservation_Action_Name = 观测临近空间
     #LOC_SSPX_Science_TelescopeObservation_Action_Reset = 放弃观测报告
     #LOC_SSPX_Science_TelescopeObservation_Action_Collect = 查看观测报告
 

--- a/GameData/StationPartsExpansionRedux/Localization/zh-cn.cfg
+++ b/GameData/StationPartsExpansionRedux/Localization/zh-cn.cfg
@@ -718,7 +718,7 @@ Localization
     #LOC_SSPX_ActionRetractProjectors = 收回投射器
     #LOC_SSPX_ActionToggleProjectors = 开关投射器
 
-    #LOC_SSPX_Science_VisualScan_Action_Name = 乘员报告
+    #LOC_SSPX_Science_VisualScan_Action_Name = 裸眼观测报告
     #LOC_SSPX_Science_VisualScan_Action_Reset = 重置报告
     #LOC_SSPX_Science_VisualScan_Action_Review = 查看报告
 


### PR DESCRIPTION
The original translator mistook the experiments visual observation with crew report.
Small problem, but it took me 2 days to find out exactly what is happening.