### PR TITLE
Restore 5 seats to PMA-5 "Dawn" Habitation Module IVA

### DIFF
--- a/Extras/StationPartsExpansionReduxIVAs/Internals/station-1875/sspx-habitation-1875-1-iva.cfg
+++ b/Extras/StationPartsExpansionReduxIVAs/Internals/station-1875/sspx-habitation-1875-1-iva.cfg
@@ -26,6 +26,18 @@ INTERNAL
 		seatTransformName = Kerbal3
 		allowCrewHelmet = false
 	}
+	MODULE
+	{
+		name = InternalSeat
+		seatTransformName = Kerbal4
+		allowCrewHelmet = false
+	}
+	MODULE
+	{
+		name = InternalSeat
+		seatTransformName = Kerbal5
+		allowCrewHelmet = false
+	}
 	PROP
 	{
 		name = NF_HTCH_IVA_Basic


### PR DESCRIPTION
This IVA had only 3 seats, now 5 as intended.